### PR TITLE
Fix webrequest header

### DIFF
--- a/engine/src/core/graph/graph.py
+++ b/engine/src/core/graph/graph.py
@@ -353,6 +353,7 @@ class Graph:
                     node_reference_pads.append(cast(pad.PropertyPad, pad_instance))
 
                 pad_instance.set_value(deserialized_value)
+                node.resolve_pads()
 
             node.resolve_pads()
             self.nodes.append(node)


### PR DESCRIPTION
Because pads values can determine whether or not other pads exist (TBD on if this is a good approach) we need to resolve_pads every time a property value is set. This also means order of pads matters. Pads are guaranteed to be loaded in order.