### PR TITLE
Change data model for saving/loading

### DIFF
--- a/engine/data/example/echo.json
+++ b/engine/data/example/echo.json
@@ -2,83 +2,107 @@
     "id": "echo",
     "name": "Hello World: Echo",
     "created_at": "2025-07-29T10:41:27.850348",
-    "updated_at": "2025-08-26T14:42:32.572946",
+    "updated_at": "2025-08-29T15:55:54.226569",
     "graph": {
         "nodes": [
             {
-                "id": "publish_7d5e1852",
+                "id": "publish_570006bb",
                 "type": "Publish",
                 "editor_name": "Publish",
                 "editor_position": [
-                    164.41386010362697,
-                    456.5556994818653
+                    288.0,
+                    576.0
                 ],
                 "editor_dimensions": [
                     256.0,
-                    422.0
+                    424.0
                 ],
                 "pads": [
                     {
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "output_274c2131",
-                                "pad": "audio"
+                                "type": "audio"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "audio"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "output_f9e7d8a2",
+                                "pad": "audio"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "video",
                         "group": "video",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "output_274c2131",
-                                "pad": "video"
+                                "type": "video"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "output_f9e7d8a2",
+                                "pad": "video"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "audio_enabled",
                         "group": "audio_enabled",
                         "type": "PropertySourcePad",
-                        "value": false,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "boolean"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "boolean"
                             }
-                        ]
+                        ],
+                        "value": false,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "video_enabled",
                         "group": "video_enabled",
                         "type": "PropertySourcePad",
-                        "value": false,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "boolean"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "boolean"
                             }
-                        ]
+                        ],
+                        "value": false,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Stream audio and video into your Gabber flow",
@@ -92,12 +116,12 @@
                 }
             },
             {
-                "id": "output_274c2131",
+                "id": "output_f9e7d8a2",
                 "type": "Output",
                 "editor_name": "Output",
                 "editor_position": [
-                    479.9251808402332,
-                    504.51789285312304
+                    696.0,
+                    660.0
                 ],
                 "editor_dimensions": [
                     256.0,
@@ -108,33 +132,45 @@
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "publish_7d5e1852",
-                            "pad": "audio"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "audio"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "publish_570006bb",
+                            "pad": "audio"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "video",
                         "group": "video",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "publish_7d5e1852",
-                            "pad": "video"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "publish_570006bb",
+                            "pad": "video"
+                        },
+                        "pad_links": []
                     }
                 ],
                 "description": "Outputs audio and video to the end user",

--- a/engine/data/example/local-conversational.json
+++ b/engine/data/example/local-conversational.json
@@ -2,83 +2,148 @@
     "id": "local-conversational",
     "name": "Local Conversational W/ Vision",
     "created_at": "2025-08-18T17:36:49.997790",
-    "updated_at": "2025-08-26T14:40:36.718544",
+    "updated_at": "2025-08-29T16:03:24.621943",
     "graph": {
         "nodes": [
             {
-                "id": "publish_51d485ce",
+                "id": "comment_6d13e5c0",
+                "type": "Comment",
+                "editor_name": "Comment",
+                "editor_position": [
+                    1428.0,
+                    600.0
+                ],
+                "editor_dimensions": [
+                    320.0,
+                    270.0
+                ],
+                "pads": [
+                    {
+                        "id": "text",
+                        "group": "text",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "This Example requires that you run qwen-omni locally. See README for instructions.",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "A comment node for adding notes and documentation to your graph",
+                "metadata": {
+                    "primary": "core",
+                    "secondary": "utility",
+                    "tags": [
+                        "documentation",
+                        "comment"
+                    ]
+                }
+            },
+            {
+                "id": "publish_1505c18b",
                 "type": "Publish",
                 "editor_name": "Publish",
                 "editor_position": [
-                    -228.0,
-                    180.0
+                    -252.0,
+                    1188.0
                 ],
                 "editor_dimensions": [
                     256.0,
-                    422.0
+                    424.0
                 ],
                 "pads": [
                     {
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "silerovad_8b46b458",
-                                "pad": "audio"
+                                "type": "audio"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "audio"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "silerovad_60fe592a",
+                                "pad": "audio"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "video",
                         "group": "video",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "fps_eedcaf02",
-                                "pad": "video_in"
+                                "type": "video"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "fps_24bdcf73",
+                                "pad": "video_in"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "audio_enabled",
                         "group": "audio_enabled",
                         "type": "PropertySourcePad",
-                        "value": false,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "boolean"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "boolean"
                             }
-                        ]
+                        ],
+                        "value": false,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "video_enabled",
                         "group": "video_enabled",
                         "type": "PropertySourcePad",
-                        "value": false,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "boolean"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "boolean"
                             }
-                        ]
+                        ],
+                        "value": false,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Stream audio and video into your Gabber flow",
@@ -92,164 +157,226 @@
                 }
             },
             {
-                "id": "silerovad_8b46b458",
+                "id": "silerovad_60fe592a",
                 "type": "SileroVAD",
                 "editor_name": "SileroVAD",
                 "editor_position": [
-                    312.0,
-                    144.0
+                    384.0,
+                    1080.0
                 ],
                 "editor_dimensions": [
-                    355.0,
-                    431.0
+                    362.0,
+                    432.0
                 ],
                 "pads": [
                     {
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "publish_51d485ce",
-                            "pad": "audio"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "audio"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "publish_1505c18b",
+                            "pad": "audio"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "audio_clip",
                         "group": "audio_clip",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "avclipzip_215e33c4",
-                                "pad": "audio_clip"
+                                "type": "audio_clip"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "audio_clip"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "avclipzip_72441925",
+                                "pad": "audio_clip"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "speech_started_trigger",
                         "group": "speech_started_trigger",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "localllm_ec07ef49",
-                                "pad": "cancel_trigger"
-                            },
-                            {
-                                "node": "kittentts_af3695c4",
-                                "pad": "cancel_trigger"
+                                "type": "trigger"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "localllm_69e9d280",
+                                "pad": "cancel_trigger"
+                            },
+                            {
+                                "node": "kittentts_3c3b7423",
+                                "pad": "cancel_trigger"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "speech_ended_trigger",
                         "group": "speech_ended_trigger",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "slidingwindow_80c47f54",
-                                "pad": "flush"
+                                "type": "trigger"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "slidingwindow_1b182aba",
+                                "pad": "flush"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "continued_speech_trigger",
                         "group": "continued_speech_trigger",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "vad_threshold",
                         "group": "vad_threshold",
                         "type": "PropertySinkPad",
-                        "value": 0.5,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "float",
+                                "maximum": 1.0,
+                                "minimum": 0.0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "float",
                                 "maximum": 1.0,
                                 "minimum": 0.0
                             }
-                        ]
+                        ],
+                        "value": 0.5,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "silence_duration_ms",
                         "group": "silence_duration_ms",
                         "type": "PropertySinkPad",
-                        "value": 500,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "float",
+                                "maximum": 3000.0,
+                                "minimum": 0.0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "float",
                                 "maximum": 3000.0,
                                 "minimum": 0.0
                             }
-                        ]
+                        ],
+                        "value": 500,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "speech_duration_ms",
                         "group": "speech_duration_ms",
                         "type": "PropertySinkPad",
-                        "value": 400,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "float",
+                                "maximum": 3000.0,
+                                "minimum": 0.0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "float",
                                 "maximum": 3000.0,
                                 "minimum": 0.0
                             }
-                        ]
+                        ],
+                        "value": 400,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "pre_speech_duration_ms",
                         "group": "pre_speech_duration_ms",
                         "type": "PropertySinkPad",
-                        "value": 100,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "float",
+                                "maximum": 1000.0,
+                                "minimum": 0.0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "float",
                                 "maximum": 1000.0,
                                 "minimum": 0.0
                             }
-                        ]
+                        ],
+                        "value": 100,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Voice Activity Detection - detects when someone is speaking",
@@ -263,485 +390,86 @@
                 }
             },
             {
-                "id": "localllm_ec07ef49",
-                "type": "LocalLLM",
-                "editor_name": "LocalLLM",
-                "editor_position": [
-                    1980.0,
-                    132.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    475.0
-                ],
-                "pads": [
-                    {
-                        "id": "run_trigger",
-                        "group": "run_trigger",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "autoconvert_12571325",
-                            "pad": "source"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "started",
-                        "group": "started",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "tool_calls_started",
-                        "group": "tool_calls_started",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "tool_calls_finished",
-                        "group": "tool_calls_finished",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "first_token",
-                        "group": "first_token",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "text_stream",
-                        "group": "text_stream",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "kittentts_af3695c4",
-                                "pad": "text"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "text_stream"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "thinking_stream",
-                        "group": "thinking_stream",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "text_stream"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "context_message",
-                        "group": "context_message",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "finished",
-                        "group": "finished",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "cancel_trigger",
-                        "group": "cancel_trigger",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "silerovad_8b46b458",
-                            "pad": "speech_started_trigger"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "context",
-                        "group": "context",
-                        "type": "PropertySinkPad",
-                        "value": [
-                            {
-                                "role": "system",
-                                "content": [
-                                    {
-                                        "type": "text",
-                                        "content": "You are a helpful assistant."
-                                    }
-                                ],
-                                "tool_calls": [],
-                                "tool_call_id": null
-                            }
-                        ],
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "llmcontext_ed05a485",
-                            "pad": "source"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "list",
-                                "max_length": null,
-                                "item_type_constraints": [
-                                    {}
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "tool_group",
-                        "group": "tool_group",
-                        "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "node_reference",
-                                "node_types": [
-                                    "ToolGroup"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "port",
-                        "group": "port",
-                        "type": "PropertySinkPad",
-                        "value": 7002,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "integer",
-                                "maximum": null,
-                                "minimum": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Send and receive responses from any Qwen-omni language model",
-                "metadata": {
-                    "primary": "ai",
-                    "secondary": "local",
-                    "tags": [
-                        "completion",
-                        "text",
-                        "qwen-omni"
-                    ]
-                }
-            },
-            {
-                "id": "llmcontext_ed05a485",
-                "type": "LLMContext",
-                "editor_name": "LLMContext",
-                "editor_position": [
-                    1392.0,
-                    240.0
-                ],
-                "editor_dimensions": [
-                    356.0,
-                    411.0
-                ],
-                "pads": [
-                    {
-                        "id": "num_inserts",
-                        "group": "config",
-                        "type": "PropertySinkPad",
-                        "value": 1,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "integer",
-                                "maximum": null,
-                                "minimum": 1
-                            }
-                        ]
-                    },
-                    {
-                        "id": "max_non_system_messages",
-                        "group": "max_non_system_messages",
-                        "type": "PropertySinkPad",
-                        "value": 64,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "integer",
-                                "maximum": null,
-                                "minimum": 0
-                            }
-                        ]
-                    },
-                    {
-                        "id": "max_videos",
-                        "group": "max_videos",
-                        "type": "PropertySinkPad",
-                        "value": 2,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "integer",
-                                "maximum": null,
-                                "minimum": 0
-                            }
-                        ]
-                    },
-                    {
-                        "id": "max_audios",
-                        "group": "max_audios",
-                        "type": "PropertySinkPad",
-                        "value": 2,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "integer",
-                                "maximum": null,
-                                "minimum": 0
-                            }
-                        ]
-                    },
-                    {
-                        "id": "max_images",
-                        "group": "max_images",
-                        "type": "PropertySinkPad",
-                        "value": 2,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "integer",
-                                "maximum": null,
-                                "minimum": 0
-                            }
-                        ]
-                    },
-                    {
-                        "id": "system_message",
-                        "group": "system_message",
-                        "type": "PropertySinkPad",
-                        "value": {
-                            "role": "system",
-                            "content": [
-                                {
-                                    "type": "text",
-                                    "content": "You are a helpful assistant."
-                                }
-                            ],
-                            "tool_calls": [],
-                            "tool_call_id": null
-                        },
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "insert_0",
-                        "group": "insert",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "createcontextmessage_41a7bd4c",
-                            "pad": "context_message"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "source",
-                        "group": "source",
-                        "type": "PropertySourcePad",
-                        "value": [
-                            {
-                                "role": "system",
-                                "content": [
-                                    {
-                                        "type": "text",
-                                        "content": "You are a helpful assistant."
-                                    }
-                                ],
-                                "tool_calls": [],
-                                "tool_call_id": null
-                            }
-                        ],
-                        "next_pads": [
-                            {
-                                "node": "localllm_ec07ef49",
-                                "pad": "context"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "list",
-                                "max_length": null,
-                                "item_type_constraints": [
-                                    {}
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "new_user_message",
-                        "group": "new_user_message",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "autoconvert_12571325",
-                                "pad": "sink"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    }
-                ],
-                "description": "Manages conversation context for language models",
-                "metadata": {
-                    "primary": "ai",
-                    "secondary": "llm",
-                    "tags": [
-                        "context",
-                        "memory"
-                    ]
-                }
-            },
-            {
-                "id": "fps_eedcaf02",
+                "id": "fps_24bdcf73",
                 "type": "FPS",
                 "editor_name": "FPS",
                 "editor_position": [
-                    168.0,
-                    648.0
+                    360.0,
+                    1668.0
                 ],
                 "editor_dimensions": [
                     256.0,
-                    203.0
+                    204.0
                 ],
                 "pads": [
                     {
                         "id": "video_in",
                         "group": "video_in",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "publish_51d485ce",
-                            "pad": "video"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "publish_1505c18b",
+                            "pad": "video"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "video_out",
                         "group": "video_out",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "slidingwindow_80c47f54",
-                                "pad": "video"
+                                "type": "video"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "slidingwindow_1b182aba",
+                                "pad": "video"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "fps",
                         "group": "fps",
                         "type": "PropertySinkPad",
-                        "value": 0.5,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "float",
+                                "maximum": 30.0,
+                                "minimum": 0.0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "float",
                                 "maximum": 30.0,
                                 "minimum": 0.0
                             }
-                        ]
+                        ],
+                        "value": 0.5,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Controls the frame rate of the video being processed",
@@ -755,67 +483,238 @@
                 }
             },
             {
-                "id": "avclipzip_215e33c4",
-                "type": "AVClipZip",
-                "editor_name": "AVClipZip",
+                "id": "slidingwindow_1b182aba",
+                "type": "SlidingWindow",
+                "editor_name": "SlidingWindow",
                 "editor_position": [
-                    768.0,
-                    408.0
+                    816.0,
+                    1524.0
                 ],
                 "editor_dimensions": [
-                    256.0,
-                    183.0
+                    292.0,
+                    288.0
                 ],
                 "pads": [
                     {
-                        "id": "video_clip",
-                        "group": "video_clip",
+                        "id": "video",
+                        "group": "video",
                         "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
                         "value": null,
                         "next_pads": [],
                         "previous_pad": {
-                            "node": "slidingwindow_80c47f54",
-                            "pad": "clip"
+                            "node": "fps_24bdcf73",
+                            "pad": "video_out"
                         },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "audio",
+                        "group": "audio",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "flush",
+                        "group": "flush",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "silerovad_60fe592a",
+                            "pad": "speech_ended_trigger"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "reset",
+                        "group": "reset",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "clip",
+                        "group": "clip",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "video_clip"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "video_clip"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "avclipzip_72441925",
+                                "pad": "video_clip"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
+                    {
+                        "id": "window_size_s",
+                        "group": "window_size_s",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "float",
+                                "maximum": null,
+                                "minimum": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "float",
+                                "maximum": null,
+                                "minimum": null
+                            }
+                        ],
+                        "value": 5,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Slides a window of media and writes based on input trigger.",
+                "metadata": {
+                    "primary": "core",
+                    "secondary": "media",
+                    "tags": [
+                        "control",
+                        "sliding_window"
+                    ]
+                }
+            },
+            {
+                "id": "avclipzip_72441925",
+                "type": "AVClipZip",
+                "editor_name": "AVClipZip",
+                "editor_position": [
+                    1188.0,
+                    1332.0
+                ],
+                "editor_dimensions": [
+                    256.0,
+                    184.0
+                ],
+                "pads": [
                     {
                         "id": "audio_clip",
                         "group": "audio_clip",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "silerovad_8b46b458",
-                            "pad": "audio_clip"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "audio_clip"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "audio_clip"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "silerovad_60fe592a",
+                            "pad": "audio_clip"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "video_clip",
+                        "group": "video_clip",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "video_clip"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "video_clip"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "slidingwindow_1b182aba",
+                            "pad": "clip"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "av_clip",
                         "group": "av_clip",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "createcontextmessage_41a7bd4c",
-                                "pad": "content"
+                                "type": "av_clip"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "av_clip"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "createcontextmessage_4c007096",
+                                "pad": "content"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Combines audio and video clips into a single av clip.",
@@ -830,179 +729,99 @@
                 }
             },
             {
-                "id": "slidingwindow_80c47f54",
-                "type": "SlidingWindow",
-                "editor_name": "SlidingWindow",
-                "editor_position": [
-                    528.0,
-                    648.0
-                ],
-                "editor_dimensions": [
-                    288.0,
-                    287.0
-                ],
-                "pads": [
-                    {
-                        "id": "video",
-                        "group": "video",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "fps_eedcaf02",
-                            "pad": "video_out"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "video"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "audio",
-                        "group": "audio",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "flush",
-                        "group": "flush",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "silerovad_8b46b458",
-                            "pad": "speech_ended_trigger"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "reset",
-                        "group": "reset",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "clip",
-                        "group": "clip",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "avclipzip_215e33c4",
-                                "pad": "video_clip"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "video_clip"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "window_size_s",
-                        "group": "window_size_s",
-                        "type": "PropertySinkPad",
-                        "value": 1,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "float",
-                                "maximum": null,
-                                "minimum": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Slides a window of media and writes based on input trigger.",
-                "metadata": {
-                    "primary": "core",
-                    "secondary": "media",
-                    "tags": [
-                        "control",
-                        "sliding_window"
-                    ]
-                }
-            },
-            {
-                "id": "createcontextmessage_41a7bd4c",
+                "id": "createcontextmessage_4c007096",
                 "type": "CreateContextMessage",
                 "editor_name": "CreateContextMessage",
                 "editor_position": [
-                    1080.0,
-                    408.0
+                    1548.0,
+                    1284.0
                 ],
                 "editor_dimensions": [
-                    266.0,
-                    195.0
+                    288.0,
+                    196.0
                 ],
                 "pads": [
                     {
                         "id": "role",
                         "group": "role",
                         "type": "PropertySinkPad",
-                        "value": "user",
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message_role"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "context_message_role"
                             }
-                        ]
+                        ],
+                        "value": "user",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "content",
                         "group": "content",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "avclipzip_215e33c4",
-                            "pad": "av_clip"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "audio_clip"
+                            },
+                            {
+                                "type": "video_clip"
+                            },
+                            {
+                                "type": "av_clip"
+                            },
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            },
+                            {
+                                "type": "video"
+                            },
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "av_clip"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "avclipzip_72441925",
+                            "pad": "av_clip"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "context_message",
                         "group": "context_message",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "llmcontext_ed05a485",
-                                "pad": "insert_0"
+                                "type": "context_message"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "context_message"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "llmcontext_ed1e9a92",
+                                "pad": "insert_0"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Creates new context messages with specified role and content",
@@ -1016,12 +835,716 @@
                 }
             },
             {
-                "id": "autoconvert_12571325",
+                "id": "llmcontext_ed1e9a92",
+                "type": "LLMContext",
+                "editor_name": "LLMContext",
+                "editor_position": [
+                    2004.0,
+                    1044.0
+                ],
+                "editor_dimensions": [
+                    371.0,
+                    440.0
+                ],
+                "pads": [
+                    {
+                        "id": "num_inserts",
+                        "group": "config",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 1
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 1
+                            }
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "max_non_system_messages",
+                        "group": "max_non_system_messages",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "value": 64,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "max_videos",
+                        "group": "max_videos",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "max_audios",
+                        "group": "max_audios",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "max_images",
+                        "group": "max_images",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "system_message",
+                        "group": "system_message",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": {
+                            "role": "system",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "content": "You are a helpful assistant."
+                                }
+                            ],
+                            "tool_calls": [],
+                            "tool_call_id": null
+                        },
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "contextmessage_f1e45e78",
+                            "pad": "context_message"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "insert_0",
+                        "group": "insert",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "createcontextmessage_4c007096",
+                            "pad": "context_message"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "insert_1",
+                        "group": "insert",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "localllm_69e9d280",
+                            "pad": "context_message"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "source",
+                        "group": "source",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "value": [
+                            {
+                                "role": "system",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "content": "You are a helpful assistant."
+                                    }
+                                ],
+                                "tool_calls": [],
+                                "tool_call_id": null
+                            }
+                        ],
+                        "next_pads": [
+                            {
+                                "node": "localllm_69e9d280",
+                                "pad": "context"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "new_user_message",
+                        "group": "new_user_message",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "autoconvert_8d35e3b8",
+                                "pad": "sink"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Manages conversation context for language models",
+                "metadata": {
+                    "primary": "ai",
+                    "secondary": "llm",
+                    "tags": [
+                        "context",
+                        "memory"
+                    ]
+                }
+            },
+            {
+                "id": "contextmessage_f1e45e78",
+                "type": "ContextMessage",
+                "editor_name": "ContextMessage",
+                "editor_position": [
+                    1572.0,
+                    1032.0
+                ],
+                "editor_dimensions": [
+                    256.0,
+                    208.0
+                ],
+                "pads": [
+                    {
+                        "id": "role",
+                        "group": "role",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message_role"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message_role"
+                            }
+                        ],
+                        "value": "system",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "content",
+                        "group": "content",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "You are a helpful assistant.",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "context_message",
+                        "group": "context_message",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": {
+                            "role": "system",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "content": "You are a helpful assistant."
+                                }
+                            ],
+                            "tool_calls": [],
+                            "tool_call_id": null
+                        },
+                        "next_pads": [
+                            {
+                                "node": "llmcontext_ed1e9a92",
+                                "pad": "system_message"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Stores and manages conversation context messages",
+                "metadata": {
+                    "primary": "ai",
+                    "secondary": "llm",
+                    "tags": [
+                        "context",
+                        "message"
+                    ]
+                }
+            },
+            {
+                "id": "localllm_69e9d280",
+                "type": "LocalLLM",
+                "editor_name": "LocalLLM",
+                "editor_position": [
+                    2688.0,
+                    960.0
+                ],
+                "editor_dimensions": [
+                    256.0,
+                    476.0
+                ],
+                "pads": [
+                    {
+                        "id": "run_trigger",
+                        "group": "run_trigger",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "autoconvert_8d35e3b8",
+                            "pad": "source"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "started",
+                        "group": "started",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "tool_calls_started",
+                        "group": "tool_calls_started",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "tool_calls_finished",
+                        "group": "tool_calls_finished",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "first_token",
+                        "group": "first_token",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "text_stream",
+                        "group": "text_stream",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "kittentts_3c3b7423",
+                                "pad": "text"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "thinking_stream",
+                        "group": "thinking_stream",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "context_message",
+                        "group": "context_message",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "llmcontext_ed1e9a92",
+                                "pad": "insert_1"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "finished",
+                        "group": "finished",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "cancel_trigger",
+                        "group": "cancel_trigger",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "silerovad_60fe592a",
+                            "pad": "speech_started_trigger"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "context",
+                        "group": "context",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "value": [
+                            {
+                                "role": "system",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "content": "You are a helpful assistant."
+                                    }
+                                ],
+                                "tool_calls": [],
+                                "tool_call_id": null
+                            }
+                        ],
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "llmcontext_ed1e9a92",
+                            "pad": "source"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "tool_group",
+                        "group": "tool_group",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "node_reference",
+                                "node_types": [
+                                    "ToolGroup"
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "node_reference",
+                                "node_types": [
+                                    "ToolGroup"
+                                ]
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "port",
+                        "group": "port",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": null
+                            }
+                        ],
+                        "value": 7002,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Send and receive responses from any Qwen-omni language model",
+                "metadata": {
+                    "primary": "ai",
+                    "secondary": "local",
+                    "tags": [
+                        "completion",
+                        "text",
+                        "qwen-omni"
+                    ]
+                }
+            },
+            {
+                "id": "autoconvert_8d35e3b8",
                 "type": "AutoConvert",
                 "editor_name": "AutoConvert",
                 "editor_position": [
-                    1812.0,
-                    420.0
+                    2484.0,
+                    1224.0
                 ],
                 "editor_dimensions": [
                     80.0,
@@ -1032,35 +1555,39 @@
                         "id": "sink",
                         "group": "sink",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "llmcontext_ed05a485",
-                            "pad": "new_user_message"
-                        },
+                        "default_allowed_types": null,
                         "allowed_types": [
                             {
                                 "type": "context_message"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "llmcontext_ed1e9a92",
+                            "pad": "new_user_message"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "source",
                         "group": "source",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "localllm_ec07ef49",
-                                "pad": "run_trigger"
-                            }
-                        ],
-                        "previous_pad": null,
+                        "default_allowed_types": null,
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "localllm_69e9d280",
+                                "pad": "run_trigger"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Automatically converts data between compatible types",
@@ -1074,105 +1601,152 @@
                 }
             },
             {
-                "id": "kittentts_af3695c4",
+                "id": "kittentts_3c3b7423",
                 "type": "KittenTTS",
                 "editor_name": "KittenTTS",
                 "editor_position": [
-                    2496.0,
-                    204.0
+                    3132.0,
+                    1056.0
                 ],
                 "editor_dimensions": [
                     256.0,
-                    244.0
+                    246.0
                 ],
                 "pads": [
                     {
                         "id": "voice_id",
                         "group": "voice_id",
                         "type": "PropertySinkPad",
-                        "value": "expr-voice-2-m",
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "expr-voice-2-m",
+                                    "expr-voice-2-f",
+                                    "expr-voice-3-m",
+                                    "expr-voice-3-f",
+                                    "expr-voice-4-m",
+                                    "expr-voice-4-f",
+                                    "expr-voice-5-m",
+                                    "expr-voice-5-f"
+                                ]
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "enum",
                                 "options": [
+                                    "expr-voice-2-m",
+                                    "expr-voice-2-f",
                                     "expr-voice-3-m",
                                     "expr-voice-3-f",
-                                    "expr-voice-2-f",
                                     "expr-voice-4-m",
-                                    "expr-voice-5-m",
                                     "expr-voice-4-f",
-                                    "expr-voice-2-m",
+                                    "expr-voice-5-m",
                                     "expr-voice-5-f"
                                 ]
                             }
-                        ]
+                        ],
+                        "value": "expr-voice-2-m",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "text",
                         "group": "text",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "localllm_ec07ef49",
-                            "pad": "text_stream"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "text_stream"
+                            },
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "text_stream"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "localllm_69e9d280",
+                            "pad": "text_stream"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "output_c591f96d",
-                                "pad": "audio"
+                                "type": "audio"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "audio"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "output_8a08420e",
+                                "pad": "audio"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "cancel_trigger",
                         "group": "cancel_trigger",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "silerovad_8b46b458",
-                            "pad": "speech_started_trigger"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "silerovad_60fe592a",
+                            "pad": "speech_started_trigger"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "complete_transcription",
                         "group": "complete_transcription",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "string",
                                 "max_length": null,
                                 "min_length": null
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Converts text to speech using Gabber's native TTS model",
@@ -1187,12 +1761,12 @@
                 }
             },
             {
-                "id": "output_c591f96d",
+                "id": "output_8a08420e",
                 "type": "Output",
                 "editor_name": "Output",
                 "editor_position": [
-                    2916.0,
-                    192.0
+                    3468.0,
+                    1020.0
                 ],
                 "editor_dimensions": [
                     256.0,
@@ -1203,30 +1777,42 @@
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "kittentts_af3695c4",
-                            "pad": "audio"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "audio"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "kittentts_3c3b7423",
+                            "pad": "audio"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "video",
                         "group": "video",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Outputs audio and video to the end user",
@@ -1236,45 +1822,6 @@
                     "tags": [
                         "output",
                         "display"
-                    ]
-                }
-            },
-            {
-                "id": "comment_6d13e5c0",
-                "type": "Comment",
-                "editor_name": "Comment",
-                "editor_position": [
-                    1008.0,
-                    -132.0
-                ],
-                "editor_dimensions": [
-                    320.0,
-                    269.0
-                ],
-                "pads": [
-                    {
-                        "id": "text",
-                        "group": "text",
-                        "type": "PropertySinkPad",
-                        "value": "This Example requires that you run qwen-omni locally. See README for instructions.",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "A comment node for adding notes and documentation to your graph",
-                "metadata": {
-                    "primary": "core",
-                    "secondary": "utility",
-                    "tags": [
-                        "documentation",
-                        "comment"
                     ]
                 }
             }

--- a/engine/data/example/local-tts.json
+++ b/engine/data/example/local-tts.json
@@ -1,1 +1,357 @@
-{"id":"local-tts","name":"Local TTS","created_at":"2025-08-18T22:10:51.327793","updated_at":"2025-08-26T14:37:39.802190","graph":{"nodes":[{"id":"kittentts_d7ec7a90","type":"KittenTTS","editor_name":"KittenTTS","editor_position":[864.0,108.0],"editor_dimensions":[256.0,244.0],"pads":[{"id":"voice_id","group":"voice_id","type":"PropertySinkPad","value":"expr-voice-3-m","next_pads":[],"previous_pad":null,"allowed_types":[{"type":"enum","options":["expr-voice-3-m","expr-voice-3-f","expr-voice-2-f","expr-voice-4-m","expr-voice-5-m","expr-voice-4-f","expr-voice-2-m","expr-voice-5-f"]}]},{"id":"text","group":"text","type":"StatelessSinkPad","value":null,"next_pads":[],"previous_pad":{"node":"chatinput_f3a1d19e","pad":"output"},"allowed_types":[{"type":"string","max_length":null,"min_length":null}]},{"id":"audio","group":"audio","type":"StatelessSourcePad","value":null,"next_pads":[{"node":"output_3e458b7d","pad":"audio"}],"previous_pad":null,"allowed_types":[{"type":"audio"}]},{"id":"cancel_trigger","group":"cancel_trigger","type":"StatelessSinkPad","value":null,"next_pads":[],"previous_pad":{"node":"autoconvert_15eb6daf","pad":"source"},"allowed_types":[{"type":"trigger"}]},{"id":"complete_transcription","group":"complete_transcription","type":"StatelessSourcePad","value":null,"next_pads":[],"previous_pad":null,"allowed_types":[{"type":"string","max_length":null,"min_length":null}]}],"description":"Converts text to speech using Gabber's native TTS model","metadata":{"primary":"local","secondary":"audio","tags":["tts","speech","gabber"]}},{"id":"chatinput_f3a1d19e","type":"ChatInput","editor_name":"ChatInput","editor_position":[420.0,156.0],"editor_dimensions":[256.0,167.0],"pads":[{"id":"output","group":"text","type":"StatelessSourcePad","value":null,"next_pads":[{"node":"kittentts_d7ec7a90","pad":"text"},{"node":"autoconvert_15eb6daf","pad":"sink"}],"previous_pad":null,"allowed_types":[{"type":"string","max_length":null,"min_length":null}]}],"description":"A chat input node to send text into your Gabber flow","metadata":{"primary":"core","secondary":"debug","tags":["input","text"]}},{"id":"output_3e458b7d","type":"Output","editor_name":"Output","editor_position":[1236.0,48.0],"editor_dimensions":[256.0,300.0],"pads":[{"id":"audio","group":"audio","type":"StatelessSinkPad","value":null,"next_pads":[],"previous_pad":{"node":"kittentts_d7ec7a90","pad":"audio"},"allowed_types":[{"type":"audio"}]},{"id":"video","group":"video","type":"StatelessSinkPad","value":null,"next_pads":[],"previous_pad":null,"allowed_types":[{"type":"video"}]}],"description":"Outputs audio and video to the end user","metadata":{"primary":"core","secondary":"media","tags":["output","display"]}},{"id":"autoconvert_15eb6daf","type":"AutoConvert","editor_name":"AutoConvert","editor_position":[720.0,348.0],"editor_dimensions":[80.0,48.0],"pads":[{"id":"sink","group":"sink","type":"StatelessSinkPad","value":null,"next_pads":[],"previous_pad":{"node":"chatinput_f3a1d19e","pad":"output"},"allowed_types":[{"type":"string","max_length":null,"min_length":null}]},{"id":"source","group":"source","type":"StatelessSourcePad","value":null,"next_pads":[{"node":"kittentts_d7ec7a90","pad":"cancel_trigger"}],"previous_pad":null,"allowed_types":[{"type":"trigger"}]}],"description":"Automatically converts data between compatible types","metadata":{"primary":"core","secondary":"utility","tags":["auto","type"]}}]}}
+{
+    "id": "local-tts",
+    "name": "Local TTS",
+    "created_at": "2025-08-18T22:10:51.327793",
+    "updated_at": "2025-08-29T16:23:01.601033",
+    "graph": {
+        "nodes": [
+            {
+                "id": "chatinput_6ab46b1b",
+                "type": "ChatInput",
+                "editor_name": "ChatInput",
+                "editor_position": [
+                    540.0,
+                    156.0
+                ],
+                "editor_dimensions": [
+                    256.0,
+                    168.0
+                ],
+                "pads": [
+                    {
+                        "id": "output",
+                        "group": "text",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "autoconvert_4d440340",
+                                "pad": "sink"
+                            },
+                            {
+                                "node": "kittentts_9ae0fd05",
+                                "pad": "text"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "A chat input node to send text into your Gabber flow",
+                "metadata": {
+                    "primary": "core",
+                    "secondary": "debug",
+                    "tags": [
+                        "input",
+                        "text"
+                    ]
+                }
+            },
+            {
+                "id": "kittentts_9ae0fd05",
+                "type": "KittenTTS",
+                "editor_name": "KittenTTS",
+                "editor_position": [
+                    1032.0,
+                    108.0
+                ],
+                "editor_dimensions": [
+                    256.0,
+                    246.0
+                ],
+                "pads": [
+                    {
+                        "id": "voice_id",
+                        "group": "voice_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "expr-voice-2-m",
+                                    "expr-voice-2-f",
+                                    "expr-voice-3-m",
+                                    "expr-voice-3-f",
+                                    "expr-voice-4-m",
+                                    "expr-voice-4-f",
+                                    "expr-voice-5-m",
+                                    "expr-voice-5-f"
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "expr-voice-2-m",
+                                    "expr-voice-2-f",
+                                    "expr-voice-3-m",
+                                    "expr-voice-3-f",
+                                    "expr-voice-4-m",
+                                    "expr-voice-4-f",
+                                    "expr-voice-5-m",
+                                    "expr-voice-5-f"
+                                ]
+                            }
+                        ],
+                        "value": "expr-voice-2-m",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "text",
+                        "group": "text",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "text_stream"
+                            },
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "chatinput_6ab46b1b",
+                            "pad": "output"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "audio",
+                        "group": "audio",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "output_48a08059",
+                                "pad": "audio"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "cancel_trigger",
+                        "group": "cancel_trigger",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "autoconvert_4d440340",
+                            "pad": "source"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "complete_transcription",
+                        "group": "complete_transcription",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Converts text to speech using Gabber's native TTS model",
+                "metadata": {
+                    "primary": "local",
+                    "secondary": "audio",
+                    "tags": [
+                        "tts",
+                        "speech",
+                        "gabber"
+                    ]
+                }
+            },
+            {
+                "id": "autoconvert_4d440340",
+                "type": "AutoConvert",
+                "editor_name": "AutoConvert",
+                "editor_position": [
+                    876.0,
+                    324.0
+                ],
+                "editor_dimensions": [
+                    80.0,
+                    48.0
+                ],
+                "pads": [
+                    {
+                        "id": "sink",
+                        "group": "sink",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "chatinput_6ab46b1b",
+                            "pad": "output"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "source",
+                        "group": "source",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "kittentts_9ae0fd05",
+                                "pad": "cancel_trigger"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Automatically converts data between compatible types",
+                "metadata": {
+                    "primary": "core",
+                    "secondary": "utility",
+                    "tags": [
+                        "auto",
+                        "type"
+                    ]
+                }
+            },
+            {
+                "id": "output_48a08059",
+                "type": "Output",
+                "editor_name": "Output",
+                "editor_position": [
+                    1356.0,
+                    60.0
+                ],
+                "editor_dimensions": [
+                    256.0,
+                    300.0
+                ],
+                "pads": [
+                    {
+                        "id": "audio",
+                        "group": "audio",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "kittentts_9ae0fd05",
+                            "pad": "audio"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "video",
+                        "group": "video",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Outputs audio and video to the end user",
+                "metadata": {
+                    "primary": "core",
+                    "secondary": "media",
+                    "tags": [
+                        "output",
+                        "display"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/engine/data/example/services-conversational.json
+++ b/engine/data/example/services-conversational.json
@@ -2,26 +2,492 @@
     "id": "services-conversational",
     "name": "Conversational w/ Remote Services",
     "created_at": "2025-08-13T13:22:09.215455",
-    "updated_at": "2025-08-26T14:34:53.581984",
+    "updated_at": "2025-08-29T16:25:31.587983",
     "graph": {
         "nodes": [
             {
-                "id": "publish_182485c7",
+                "id": "subgraph_c9c66609",
+                "type": "SubGraph",
+                "editor_name": "Conversational w/ Remote Services",
+                "editor_position": [
+                    408.0,
+                    804.0
+                ],
+                "editor_dimensions": [
+                    346.0,
+                    644.0
+                ],
+                "pads": [
+                    {
+                        "id": "__subgraph_id__",
+                        "group": "subgraph",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "conversational-services",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "llm_api_key",
+                        "group": "api_key",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": [
+                                    {
+                                        "updated_at": "2025-08-29T16:25:16.729805",
+                                        "created_at": "2025-08-29T16:25:16.729808",
+                                        "id": "EXAMPLE_SECRET",
+                                        "name": "EXAMPLE_SECRET"
+                                    }
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": [
+                                    {
+                                        "updated_at": "2025-08-29T16:25:16.729805",
+                                        "created_at": "2025-08-29T16:25:16.729808",
+                                        "id": "EXAMPLE_SECRET",
+                                        "name": "EXAMPLE_SECRET"
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "stt_api_key",
+                        "group": "api_key",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": [
+                                    {
+                                        "updated_at": "2025-08-29T16:25:16.729805",
+                                        "created_at": "2025-08-29T16:25:16.729808",
+                                        "id": "EXAMPLE_SECRET",
+                                        "name": "EXAMPLE_SECRET"
+                                    }
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": [
+                                    {
+                                        "updated_at": "2025-08-29T16:25:16.729805",
+                                        "created_at": "2025-08-29T16:25:16.729808",
+                                        "id": "EXAMPLE_SECRET",
+                                        "name": "EXAMPLE_SECRET"
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "tts_api_key",
+                        "group": "api_key",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": [
+                                    {
+                                        "updated_at": "2025-08-29T16:25:16.729805",
+                                        "created_at": "2025-08-29T16:25:16.729808",
+                                        "id": "EXAMPLE_SECRET",
+                                        "name": "EXAMPLE_SECRET"
+                                    }
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": [
+                                    {
+                                        "updated_at": "2025-08-29T16:25:16.729805",
+                                        "created_at": "2025-08-29T16:25:16.729808",
+                                        "id": "EXAMPLE_SECRET",
+                                        "name": "EXAMPLE_SECRET"
+                                    }
+                                ]
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "audio_in",
+                        "group": "audio",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "publish_438407b4",
+                            "pad": "audio"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "audio_out",
+                        "group": "audio",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "output_fe3e87fe",
+                                "pad": "audio"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "llm_base_url",
+                        "group": "base_url",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "https://api.openai.com/v1",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "llm_context",
+                        "group": "context",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "value": [
+                            {
+                                "role": "system",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "content": "You are a helpful assistant."
+                                    }
+                                ],
+                                "tool_calls": [],
+                                "tool_call_id": null
+                            }
+                        ],
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "llmcontext_9fe20bd3",
+                            "pad": "source"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "new_assistant_message",
+                        "group": "context_message",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "llmcontext_9fe20bd3",
+                                "pad": "insert_1"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "new_user_message",
+                        "group": "context_message",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "llmcontext_9fe20bd3",
+                                "pad": "insert_0"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "llm_model",
+                        "group": "model",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "gpt-4.1-mini",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "run_trigger",
+                        "group": "run_trigger",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "autoconvert_7f74cad5",
+                            "pad": "source"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "stt_service",
+                        "group": "service",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "assembly_ai",
+                                    "local_kyutai",
+                                    "deepgram"
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "local_kyutai",
+                                    "assembly_ai",
+                                    "deepgram"
+                                ]
+                            }
+                        ],
+                        "value": "assembly_ai",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "tts_service",
+                        "group": "service",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "gabber",
+                                    "cartesia",
+                                    "elevenlabs"
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "cartesia",
+                                    "elevenlabs",
+                                    "gabber"
+                                ]
+                            }
+                        ],
+                        "value": "gabber",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "tool_group",
+                        "group": "tool_group",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "node_reference",
+                                "node_types": [
+                                    "ToolGroup"
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "node_reference",
+                                "node_types": [
+                                    "ToolGroup"
+                                ]
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "tts_voice_id",
+                        "group": "voice_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "626c3b02-2d2a-4a93-b3e7-be35fd2b95cd",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "A reusable subgraph that can be used as a node in other graphs",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "composite",
+                    "tags": [
+                        "reusable",
+                        "nested"
+                    ]
+                }
+            },
+            {
+                "id": "publish_438407b4",
                 "type": "Publish",
                 "editor_name": "Publish",
                 "editor_position": [
-                    -444.0,
-                    732.0
+                    -396.0,
+                    792.0
                 ],
                 "editor_dimensions": [
                     256.0,
-                    422.0
+                    424.0
                 ],
                 "pads": [
                     {
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
                         "value": null,
                         "next_pads": [
                             {
@@ -30,50 +496,64 @@
                             }
                         ],
                         "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
+                        "pad_links": []
                     },
                     {
                         "id": "video",
                         "group": "video",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "video"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "audio_enabled",
                         "group": "audio_enabled",
                         "type": "PropertySourcePad",
-                        "value": false,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "boolean"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "boolean"
                             }
-                        ]
+                        ],
+                        "value": false,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "video_enabled",
                         "group": "video_enabled",
                         "type": "PropertySourcePad",
-                        "value": false,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "boolean"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "boolean"
                             }
-                        ]
+                        ],
+                        "value": false,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Stream audio and video into your Gabber flow",
@@ -87,155 +567,212 @@
                 }
             },
             {
-                "id": "autoconvert_08a0110c",
-                "type": "AutoConvert",
-                "editor_name": "AutoConvert",
+                "id": "output_fe3e87fe",
+                "type": "Output",
+                "editor_name": "Output",
                 "editor_position": [
-                    396.0,
-                    1308.0
+                    948.0,
+                    876.0
                 ],
                 "editor_dimensions": [
-                    80.0,
-                    48.0
+                    256.0,
+                    300.0
                 ],
                 "pads": [
                     {
-                        "id": "sink",
-                        "group": "sink",
+                        "id": "audio",
+                        "group": "audio",
                         "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
                         "value": null,
                         "next_pads": [],
                         "previous_pad": {
-                            "node": "llmcontext_291675c3",
-                            "pad": "new_user_message"
+                            "node": "subgraph_c9c66609",
+                            "pad": "audio_out"
                         },
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
+                        "pad_links": []
                     },
                     {
-                        "id": "source",
-                        "group": "source",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "id": "video",
+                        "group": "video",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
                             {
-                                "node": "subgraph_c9c66609",
-                                "pad": "respond_trigger"
+                                "type": "video"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
-                                "type": "trigger"
+                                "type": "video"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
-                "description": "Automatically converts data between compatible types",
+                "description": "Outputs audio and video to the end user",
                 "metadata": {
                     "primary": "core",
-                    "secondary": "utility",
+                    "secondary": "media",
                     "tags": [
-                        "auto",
-                        "type"
+                        "output",
+                        "display"
                     ]
                 }
             },
             {
-                "id": "llmcontext_291675c3",
+                "id": "llmcontext_9fe20bd3",
                 "type": "LLMContext",
                 "editor_name": "LLMContext",
                 "editor_position": [
-                    -48.0,
-                    1224.0
+                    -276.0,
+                    1284.0
                 ],
                 "editor_dimensions": [
-                    356.0,
-                    439.0
+                    371.0,
+                    440.0
                 ],
                 "pads": [
                     {
                         "id": "num_inserts",
                         "group": "config",
                         "type": "PropertySinkPad",
-                        "value": 2,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 1
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "integer",
                                 "maximum": null,
                                 "minimum": 1
                             }
-                        ]
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "max_non_system_messages",
                         "group": "max_non_system_messages",
                         "type": "PropertySinkPad",
-                        "value": 64,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "integer",
                                 "maximum": null,
                                 "minimum": 0
                             }
-                        ]
+                        ],
+                        "value": 64,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "max_videos",
                         "group": "max_videos",
                         "type": "PropertySinkPad",
-                        "value": 2,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "integer",
                                 "maximum": null,
                                 "minimum": 0
                             }
-                        ]
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "max_audios",
                         "group": "max_audios",
                         "type": "PropertySinkPad",
-                        "value": 2,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "integer",
                                 "maximum": null,
                                 "minimum": 0
                             }
-                        ]
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "max_images",
                         "group": "max_images",
                         "type": "PropertySinkPad",
-                        "value": 2,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "integer",
+                                "maximum": null,
+                                "minimum": 0
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "integer",
                                 "maximum": null,
                                 "minimum": 0
                             }
-                        ]
+                        ],
+                        "value": 2,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "system_message",
                         "group": "system_message",
                         "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
                         "value": {
                             "role": "system",
                             "content": [
@@ -249,51 +786,77 @@
                         },
                         "next_pads": [],
                         "previous_pad": {
-                            "node": "contextmessage_9db6e955",
+                            "node": "contextmessage_969a98d2",
                             "pad": "context_message"
                         },
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
+                        "pad_links": []
                     },
                     {
                         "id": "insert_0",
                         "group": "insert",
                         "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
                         "value": null,
                         "next_pads": [],
                         "previous_pad": {
                             "node": "subgraph_c9c66609",
                             "pad": "new_user_message"
                         },
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
+                        "pad_links": []
                     },
                     {
                         "id": "insert_1",
                         "group": "insert",
                         "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
                         "value": null,
                         "next_pads": [],
                         "previous_pad": {
                             "node": "subgraph_c9c66609",
                             "pad": "new_assistant_message"
                         },
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
+                        "pad_links": []
                     },
                     {
                         "id": "source",
                         "group": "source",
                         "type": "PropertySourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
                         "value": [
                             {
                                 "role": "system",
@@ -314,33 +877,31 @@
                             }
                         ],
                         "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "list",
-                                "max_length": null,
-                                "item_type_constraints": [
-                                    {}
-                                ]
-                            }
-                        ]
+                        "pad_links": []
                     },
                     {
                         "id": "new_user_message",
                         "group": "new_user_message",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "autoconvert_08a0110c",
-                                "pad": "sink"
+                                "type": "context_message"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "context_message"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "autoconvert_7f74cad5",
+                                "pad": "sink"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Manages conversation context for language models",
@@ -354,399 +915,136 @@
                 }
             },
             {
-                "id": "output_ff7ff2f5",
-                "type": "Output",
-                "editor_name": "Output",
+                "id": "autoconvert_7f74cad5",
+                "type": "AutoConvert",
+                "editor_name": "AutoConvert",
                 "editor_position": [
-                    1104.0,
-                    792.0
+                    180.0,
+                    1404.0
                 ],
                 "editor_dimensions": [
-                    256.0,
-                    300.0
+                    80.0,
+                    48.0
                 ],
                 "pads": [
                     {
-                        "id": "audio",
-                        "group": "audio",
+                        "id": "sink",
+                        "group": "sink",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "subgraph_c9c66609",
-                            "pad": "audio_out"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "video",
-                        "group": "video",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "video"
-                            }
-                        ]
-                    }
-                ],
-                "description": "Outputs audio and video to the end user",
-                "metadata": {
-                    "primary": "core",
-                    "secondary": "media",
-                    "tags": [
-                        "output",
-                        "display"
-                    ]
-                }
-            },
-            {
-                "id": "subgraph_c9c66609",
-                "type": "SubGraph",
-                "editor_name": "Conversational w/ Remote Services",
-                "editor_position": [
-                    588.0,
-                    792.0
-                ],
-                "editor_dimensions": [
-                    347.0,
-                    641.0
-                ],
-                "pads": [
-                    {
-                        "id": "__subgraph_id__",
-                        "group": "subgraph",
-                        "type": "PropertySinkPad",
-                        "value": "conversational-services",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    },
-                    {
-                        "id": "llm_api_key",
-                        "group": "api_key",
-                        "type": "PropertySinkPad",
-                        "value": "",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "secret",
-                                "options": []
-                            }
-                        ]
-                    },
-                    {
-                        "id": "stt_api_key",
-                        "group": "api_key",
-                        "type": "PropertySinkPad",
-                        "value": "",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "secret",
-                                "options": []
-                            }
-                        ]
-                    },
-                    {
-                        "id": "tts_api_key",
-                        "group": "api_key",
-                        "type": "PropertySinkPad",
-                        "value": "",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "secret",
-                                "options": []
-                            }
-                        ]
-                    },
-                    {
-                        "id": "audio_in",
-                        "group": "audio",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "publish_182485c7",
-                            "pad": "audio"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "audio_out",
-                        "group": "audio",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "output_ff7ff2f5",
-                                "pad": "audio"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "llm_base_url",
-                        "group": "base_url",
-                        "type": "PropertySinkPad",
-                        "value": "https://api.openai.com/v1",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    },
-                    {
-                        "id": "llm_context",
-                        "group": "context",
-                        "type": "PropertySinkPad",
-                        "value": [
-                            {
-                                "role": "system",
-                                "content": [
-                                    {
-                                        "type": "text",
-                                        "content": "You are a helpful assistant."
-                                    }
-                                ],
-                                "tool_calls": [],
-                                "tool_call_id": null
-                            }
-                        ],
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "llmcontext_291675c3",
-                            "pad": "source"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "list",
-                                "max_length": null,
-                                "item_type_constraints": [
-                                    {}
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "new_assistant_message",
-                        "group": "context_message",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "llmcontext_291675c3",
-                                "pad": "insert_1"
-                            }
-                        ],
-                        "previous_pad": null,
+                        "default_allowed_types": null,
                         "allowed_types": [
                             {
                                 "type": "context_message"
                             }
-                        ]
-                    },
-                    {
-                        "id": "new_user_message",
-                        "group": "context_message",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "llmcontext_291675c3",
-                                "pad": "insert_0"
-                            }
                         ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "llm_model",
-                        "group": "model",
-                        "type": "PropertySinkPad",
-                        "value": "gpt-4.1-mini",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    },
-                    {
-                        "id": "respond_trigger",
-                        "group": "run_trigger",
-                        "type": "StatelessSinkPad",
                         "value": null,
                         "next_pads": [],
                         "previous_pad": {
-                            "node": "autoconvert_08a0110c",
-                            "pad": "source"
+                            "node": "llmcontext_9fe20bd3",
+                            "pad": "new_user_message"
                         },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "source",
+                        "group": "source",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": null,
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
-                    },
-                    {
-                        "id": "stt_service",
-                        "group": "service",
-                        "type": "PropertySinkPad",
-                        "value": "assembly_ai",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "enum",
-                                "options": [
-                                    "local_kyutai",
-                                    "deepgram",
-                                    "assembly_ai"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "tts_service",
-                        "group": "service",
-                        "type": "PropertySinkPad",
-                        "value": "gabber",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "enum",
-                                "options": [
-                                    "gabber",
-                                    "elevenlabs",
-                                    "cartesia"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "tool_group",
-                        "group": "tool_group",
-                        "type": "PropertySinkPad",
+                        ],
                         "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
+                        "next_pads": [
                             {
-                                "type": "node_reference",
-                                "node_types": [
-                                    "ToolGroup"
-                                ]
+                                "node": "subgraph_c9c66609",
+                                "pad": "run_trigger"
                             }
-                        ]
-                    },
-                    {
-                        "id": "tts_voice_id",
-                        "group": "voice_id",
-                        "type": "PropertySinkPad",
-                        "value": "626c3b02-2d2a-4a93-b3e7-be35fd2b95cd",
-                        "next_pads": [],
+                        ],
                         "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
+                        "pad_links": []
                     }
                 ],
-                "description": "A reusable subgraph that can be used as a node in other graphs",
+                "description": "Automatically converts data between compatible types",
                 "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "composite",
+                    "primary": "core",
+                    "secondary": "utility",
                     "tags": [
-                        "reusable",
-                        "nested"
+                        "auto",
+                        "type"
                     ]
                 }
             },
             {
-                "id": "contextmessage_9db6e955",
+                "id": "contextmessage_969a98d2",
                 "type": "ContextMessage",
                 "editor_name": "ContextMessage",
                 "editor_position": [
-                    -396.0,
-                    1272.0
+                    -636.0,
+                    1404.0
                 ],
                 "editor_dimensions": [
                     256.0,
-                    207.0
+                    208.0
                 ],
                 "pads": [
                     {
                         "id": "role",
                         "group": "role",
                         "type": "PropertySinkPad",
-                        "value": "system",
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message_role"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "context_message_role"
                             }
-                        ]
+                        ],
+                        "value": "system",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "content",
                         "group": "content",
                         "type": "PropertySinkPad",
-                        "value": "You are a helpful assistant.",
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "string",
                                 "max_length": null,
                                 "min_length": null
                             }
-                        ]
+                        ],
+                        "value": "You are a helpful assistant.",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "context_message",
                         "group": "context_message",
                         "type": "PropertySourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
                         "value": {
                             "role": "system",
                             "content": [
@@ -760,16 +1058,12 @@
                         },
                         "next_pads": [
                             {
-                                "node": "llmcontext_291675c3",
+                                "node": "llmcontext_9fe20bd3",
                                 "pad": "system_message"
                             }
                         ],
                         "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
+                        "pad_links": []
                     }
                 ],
                 "description": "Stores and manages conversation context messages",

--- a/engine/data/sub_graph/conversational-services.json
+++ b/engine/data/sub_graph/conversational-services.json
@@ -1,942 +1,194 @@
 {
     "id": "conversational-services",
     "name": "Conversational w/ Remote Services",
-    "created_at": "2025-07-29T21:43:30.505415",
-    "updated_at": "2025-08-26T10:53:42.821127",
+    "created_at": "2025-08-29T13:59:02.193539",
+    "updated_at": "2025-08-29T14:14:12.758828",
     "graph": {
         "nodes": [
             {
-                "id": "proxypropertysink_5040f56b",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    216.0,
-                    528.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    167.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "openaicompatiblellm_e89fdde4",
-                                "pad": "context"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "list",
-                                "max_length": null,
-                                "item_type_constraints": [
-                                    {}
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "llm_context",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "proxystatelesssink_e383d515",
-                "type": "ProxyStatelessSink",
-                "editor_name": "ProxyStatelessSink",
-                "editor_position": [
-                    -444.0,
-                    -240.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    167.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "stt_1cfdeb01",
-                                "pad": "audio"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "audio_in",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a stateless sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "stateless",
-                        "proxy"
-                    ]
-                }
-            },
-            {
-                "id": "proxypropertysink_60680683",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    -444.0,
-                    -60.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    172.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "stt_1cfdeb01",
-                                "pad": "service"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "enum",
-                                "options": [
-                                    "assembly_ai",
-                                    "deepgram",
-                                    "local_kyutai"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "stt_service",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "createcontextmessage_069d591b",
-                "type": "CreateContextMessage",
-                "editor_name": "CreateContextMessage",
-                "editor_position": [
-                    216.0,
-                    -156.0
-                ],
-                "editor_dimensions": [
-                    266.0,
-                    195.0
-                ],
-                "pads": [
-                    {
-                        "id": "role",
-                        "group": "role",
-                        "type": "PropertySinkPad",
-                        "value": "user",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "context_message_role"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "content",
-                        "group": "content",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "stt_1cfdeb01",
-                            "pad": "speech_clip"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "audio_clip"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "context_message",
-                        "group": "context_message",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "proxystatelesssource_7813d651",
-                                "pad": "proxy"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    }
-                ],
-                "description": "Creates new context messages with specified role and content",
-                "metadata": {
-                    "primary": "ai",
-                    "secondary": "llm",
-                    "tags": [
-                        "context",
-                        "message"
-                    ]
-                }
-            },
-            {
-                "id": "proxystatelesssource_7813d651",
-                "type": "ProxyStatelessSource",
-                "editor_name": "ProxyStatelessSource",
-                "editor_position": [
-                    552.0,
-                    -156.0
-                ],
-                "editor_dimensions": [
-                    266.0,
-                    167.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "createcontextmessage_069d591b",
-                            "pad": "context_message"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "new_user_message",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Proxy source pad for subgraph connections",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "source",
-                    "tags": [
-                        "stateless",
-                        "proxy"
-                    ]
-                }
-            },
-            {
-                "id": "proxystatelesssink_4ec5373c",
-                "type": "ProxyStatelessSink",
-                "editor_name": "ProxyStatelessSink",
-                "editor_position": [
-                    216.0,
-                    132.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    167.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "openaicompatiblellm_e89fdde4",
-                                "pad": "run_trigger"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "respond_trigger",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a stateless sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "stateless",
-                        "proxy"
-                    ]
-                }
-            },
-            {
-                "id": "tts_57f02895",
-                "type": "TTS",
-                "editor_name": "TTS",
-                "editor_position": [
-                    1428.0,
-                    420.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    324.0
-                ],
-                "pads": [
-                    {
-                        "id": "service",
-                        "group": "service",
-                        "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_64ff72da",
-                            "pad": "proxy"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "enum",
-                                "options": [
-                                    "gabber",
-                                    "cartesia",
-                                    "elevenlabs"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "api_key",
-                        "group": "api_key",
-                        "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_9cdcde81",
-                            "pad": "proxy"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "secret",
-                                "options": []
-                            }
-                        ]
-                    },
-                    {
-                        "id": "voice_id",
-                        "group": "voice_id",
-                        "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_dfe7687f",
-                            "pad": "proxy"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    },
-                    {
-                        "id": "text",
-                        "group": "text",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "openaicompatiblellm_e89fdde4",
-                            "pad": "text_stream"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "text_stream"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "audio",
-                        "group": "audio",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "proxystatelesssource_b875c693",
-                                "pad": "proxy"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "cancel_trigger",
-                        "group": "cancel_trigger",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "stt_1cfdeb01",
-                            "pad": "speech_started"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "trigger"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "complete_transcription",
-                        "group": "complete_transcription",
-                        "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Converts text to speech using Gabber's native TTS model",
-                "metadata": {
-                    "primary": "ai",
-                    "secondary": "audio",
-                    "tags": [
-                        "tts",
-                        "speech",
-                        "gabber"
-                    ]
-                }
-            },
-            {
-                "id": "proxypropertysink_64ff72da",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    1056.0,
-                    12.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    172.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "tts_57f02895",
-                                "pad": "service"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "enum",
-                                "options": [
-                                    "gabber",
-                                    "cartesia",
-                                    "elevenlabs"
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "tts_service",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "proxypropertysink_9cdcde81",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    1056.0,
-                    204.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    179.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "tts_57f02895",
-                                "pad": "api_key"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "secret",
-                                "options": []
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "tts_api_key",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "proxypropertysink_dfe7687f",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    1056.0,
-                    396.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    179.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "tts_57f02895",
-                                "pad": "voice_id"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "tts_voice_id",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "proxystatelesssource_b875c693",
-                "type": "ProxyStatelessSource",
-                "editor_name": "ProxyStatelessSource",
-                "editor_position": [
-                    1836.0,
-                    456.0
-                ],
-                "editor_dimensions": [
-                    266.0,
-                    167.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "tts_57f02895",
-                            "pad": "audio"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "audio"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "audio_out",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Proxy source pad for subgraph connections",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "source",
-                    "tags": [
-                        "stateless",
-                        "proxy"
-                    ]
-                }
-            },
-            {
-                "id": "proxystatelesssource_3949aad0",
-                "type": "ProxyStatelessSource",
-                "editor_name": "ProxyStatelessSource",
-                "editor_position": [
-                    1116.0,
-                    828.0
-                ],
-                "editor_dimensions": [
-                    266.0,
-                    167.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "openaicompatiblellm_e89fdde4",
-                            "pad": "context_message"
-                        },
-                        "allowed_types": [
-                            {
-                                "type": "context_message"
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "new_assistant_message",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Proxy source pad for subgraph connections",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "source",
-                    "tags": [
-                        "stateless",
-                        "proxy"
-                    ]
-                }
-            },
-            {
-                "id": "stt_1cfdeb01",
+                "id": "stt_cbb66806",
                 "type": "STT",
                 "editor_name": "STT",
                 "editor_position": [
-                    -120.0,
-                    -180.0
+                    -24.0,
+                    -516.0
                 ],
                 "editor_dimensions": [
                     256.0,
-                    312.0
+                    314.0
                 ],
                 "pads": [
                     {
                         "id": "service",
                         "group": "service",
                         "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_60680683",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "assembly_ai",
+                                    "local_kyutai",
+                                    "deepgram"
+                                ]
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "enum",
                                 "options": [
                                     "assembly_ai",
-                                    "deepgram",
-                                    "local_kyutai"
+                                    "local_kyutai",
+                                    "deepgram"
                                 ]
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_0cbb1071",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "audio",
                         "group": "audio",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxystatelesssink_e383d515",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "audio"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxystatelesssink_cd567dbf",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "speech_clip",
                         "group": "speech_clip",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "createcontextmessage_069d591b",
-                                "pad": "content"
+                                "type": "audio_clip"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "audio_clip"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "createcontextmessage_54489e88",
+                                "pad": "content"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "speech_started",
                         "group": "speech_started",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "tts_57f02895",
-                                "pad": "cancel_trigger"
-                            },
-                            {
-                                "node": "openaicompatiblellm_e89fdde4",
-                                "pad": "cancel_trigger"
+                                "type": "trigger"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "openaicompatiblellm_d2f7e473",
+                                "pad": "cancel_trigger"
+                            },
+                            {
+                                "node": "tts_b60f46fe",
+                                "pad": "cancel_trigger"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "speech_ended",
                         "group": "speech_ended",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "final_transcription",
                         "group": "final_transcription",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "string",
                                 "max_length": null,
                                 "min_length": null
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "api_key",
                         "group": "api_key",
                         "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_4371b8ec",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": []
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "secret",
                                 "options": []
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_083c9183",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     }
                 ],
                 "description": "Speech-to-Text",
@@ -953,232 +205,237 @@
                 }
             },
             {
-                "id": "proxypropertysink_4371b8ec",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    -444.0,
-                    144.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    179.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "stt_1cfdeb01",
-                                "pad": "api_key"
-                            }
-                        ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "secret",
-                                "options": []
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "stt_api_key",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "openaicompatiblellm_e89fdde4",
+                "id": "openaicompatiblellm_d2f7e473",
                 "type": "OpenAICompatibleLLM",
                 "editor_name": "OpenAICompatibleLLM",
                 "editor_position": [
-                    660.0,
-                    204.0
+                    684.0,
+                    -48.0
                 ],
                 "editor_dimensions": [
-                    259.0,
-                    555.0
+                    280.0,
+                    556.0
                 ],
                 "pads": [
                     {
                         "id": "run_trigger",
                         "group": "run_trigger",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxystatelesssink_4ec5373c",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxystatelesssink_43bd65cf",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "started",
                         "group": "started",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "tool_calls_started",
                         "group": "tool_calls_started",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "tool_calls_finished",
                         "group": "tool_calls_finished",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "first_token",
                         "group": "first_token",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "text_stream",
                         "group": "text_stream",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "tts_57f02895",
-                                "pad": "text"
+                                "type": "text_stream"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "text_stream"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "tts_b60f46fe",
+                                "pad": "text"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "thinking_stream",
                         "group": "thinking_stream",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "text_stream"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "context_message",
                         "group": "context_message",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [
+                        "default_allowed_types": [
                             {
-                                "node": "proxystatelesssource_3949aad0",
-                                "pad": "proxy"
+                                "type": "context_message"
                             }
                         ],
-                        "previous_pad": null,
                         "allowed_types": [
                             {
                                 "type": "context_message"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "proxystatelesssource_c70c3f18",
+                                "pad": "proxy"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "finished",
                         "group": "finished",
                         "type": "StatelessSourcePad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "cancel_trigger",
                         "group": "cancel_trigger",
                         "type": "StatelessSinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "stt_1cfdeb01",
-                            "pad": "speech_started"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "trigger"
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "stt_cbb66806",
+                            "pad": "speech_started"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "context",
                         "group": "context",
                         "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_5040f56b",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "list",
@@ -1187,18 +444,27 @@
                                     {}
                                 ]
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_d5089820",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "tool_group",
                         "group": "tool_group",
                         "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_0c193ca8",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "node_reference",
+                                "node_types": [
+                                    "ToolGroup"
+                                ]
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "node_reference",
@@ -1206,60 +472,90 @@
                                     "ToolGroup"
                                 ]
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_cdda2d5d",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "base_url",
                         "group": "base_url",
                         "type": "PropertySinkPad",
-                        "value": "https://api.openai.com/v1",
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_c985d3c0",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "string",
                                 "max_length": null,
                                 "min_length": null
                             }
-                        ]
+                        ],
+                        "value": "https://api.openai.com/v1",
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_db0b7b0c",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "api_key",
                         "group": "api_key",
                         "type": "PropertySinkPad",
-                        "value": null,
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_9453004e",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": []
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "secret",
                                 "options": []
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_ffda675d",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     },
                     {
                         "id": "model",
                         "group": "model",
                         "type": "PropertySinkPad",
-                        "value": "gpt-4.1-mini",
-                        "next_pads": [],
-                        "previous_pad": {
-                            "node": "proxypropertysink_43a0bb25",
-                            "pad": "proxy"
-                        },
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "string",
                                 "max_length": null,
                                 "min_length": null
                             }
-                        ]
+                        ],
+                        "value": "gpt-4.1-mini",
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_415afe7f",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
                     }
                 ],
                 "description": "Send and receive responses from any OpenAI-compatible language model",
@@ -1274,206 +570,539 @@
                 }
             },
             {
-                "id": "proxypropertysink_c985d3c0",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
+                "id": "proxystatelesssink_cd567dbf",
+                "type": "ProxyStatelessSink",
+                "editor_name": "ProxyStatelessSink",
                 "editor_position": [
-                    216.0,
-                    336.0
+                    -636.0,
+                    -456.0
                 ],
                 "editor_dimensions": [
-                    256.0,
-                    179.0
+                    273.0,
+                    168.0
                 ],
                 "pads": [
                     {
                         "id": "proxy",
                         "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": "https://api.openai.com/v1",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
                         "next_pads": [
                             {
-                                "node": "openaicompatiblellm_e89fdde4",
-                                "pad": "base_url"
+                                "node": "stt_cbb66806",
+                                "pad": "audio"
                             }
                         ],
                         "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
+                        "pad_links": []
                     },
                     {
                         "id": "pad_id",
                         "group": "pad_id",
                         "type": "PropertySinkPad",
-                        "value": "llm_base_url",
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "string",
                                 "max_length": null,
                                 "min_length": null
                             }
-                        ]
+                        ],
+                        "value": "audio_in",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "description": "Create a stateless sink pad that is exposed when using your subgraph in a flow",
                 "metadata": {
                     "primary": "subgraph",
                     "secondary": "sink",
                     "tags": [
-                        "property",
-                        "sink"
+                        "stateless",
+                        "proxy"
                     ]
                 }
             },
             {
-                "id": "proxypropertysink_9453004e",
+                "id": "proxystatelesssink_43bd65cf",
+                "type": "ProxyStatelessSink",
+                "editor_name": "ProxyStatelessSink",
+                "editor_position": [
+                    264.0,
+                    -84.0
+                ],
+                "editor_dimensions": [
+                    273.0,
+                    168.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "openaicompatiblellm_d2f7e473",
+                                "pad": "run_trigger"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "run_trigger",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a stateless sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "stateless",
+                        "proxy"
+                    ]
+                }
+            },
+            {
+                "id": "createcontextmessage_54489e88",
+                "type": "CreateContextMessage",
+                "editor_name": "CreateContextMessage",
+                "editor_position": [
+                    408.0,
+                    -588.0
+                ],
+                "editor_dimensions": [
+                    288.0,
+                    196.0
+                ],
+                "pads": [
+                    {
+                        "id": "role",
+                        "group": "role",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message_role"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message_role"
+                            }
+                        ],
+                        "value": "user",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "content",
+                        "group": "content",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio_clip"
+                            },
+                            {
+                                "type": "video_clip"
+                            },
+                            {
+                                "type": "av_clip"
+                            },
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            },
+                            {
+                                "type": "video"
+                            },
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio_clip"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "stt_cbb66806",
+                            "pad": "speech_clip"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "context_message",
+                        "group": "context_message",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "proxystatelesssource_2b7fb171",
+                                "pad": "proxy"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Creates new context messages with specified role and content",
+                "metadata": {
+                    "primary": "ai",
+                    "secondary": "llm",
+                    "tags": [
+                        "context",
+                        "message"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_083c9183",
                 "type": "ProxyPropertySink",
                 "editor_name": "ProxyPropertySink",
                 "editor_position": [
-                    216.0,
-                    924.0
+                    -636.0,
+                    -276.0
                 ],
                 "editor_dimensions": [
-                    256.0,
-                    179.0
+                    266.0,
+                    180.0
                 ],
                 "pads": [
                     {
                         "id": "proxy",
                         "group": "proxy",
                         "type": "PropertySourcePad",
-                        "value": null,
-                        "next_pads": [
-                            {
-                                "node": "openaicompatiblellm_e89fdde4",
-                                "pad": "api_key"
-                            }
-                        ],
-                        "previous_pad": null,
+                        "default_allowed_types": null,
                         "allowed_types": [
                             {
                                 "type": "secret",
                                 "options": []
                             }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "llm_api_key",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "proxypropertysink_43a0bb25",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    216.0,
-                    1128.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    179.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
-                        "value": "gpt-4.1-mini",
-                        "next_pads": [
-                            {
-                                "node": "openaicompatiblellm_e89fdde4",
-                                "pad": "model"
-                            }
                         ],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    },
-                    {
-                        "id": "pad_id",
-                        "group": "pad_id",
-                        "type": "PropertySinkPad",
-                        "value": "llm_model",
-                        "next_pads": [],
-                        "previous_pad": null,
-                        "allowed_types": [
-                            {
-                                "type": "string",
-                                "max_length": null,
-                                "min_length": null
-                            }
-                        ]
-                    }
-                ],
-                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
-                "metadata": {
-                    "primary": "subgraph",
-                    "secondary": "sink",
-                    "tags": [
-                        "property",
-                        "sink"
-                    ]
-                }
-            },
-            {
-                "id": "proxypropertysink_0c193ca8",
-                "type": "ProxyPropertySink",
-                "editor_name": "ProxyPropertySink",
-                "editor_position": [
-                    216.0,
-                    732.0
-                ],
-                "editor_dimensions": [
-                    256.0,
-                    167.0
-                ],
-                "pads": [
-                    {
-                        "id": "proxy",
-                        "group": "proxy",
-                        "type": "PropertySourcePad",
                         "value": null,
                         "next_pads": [
                             {
-                                "node": "openaicompatiblellm_e89fdde4",
-                                "pad": "tool_group"
+                                "node": "stt_cbb66806",
+                                "pad": "api_key"
                             }
                         ],
                         "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "stt_api_key",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_0cbb1071",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    -636.0,
+                    -648.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    174.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "assembly_ai",
+                                    "local_kyutai",
+                                    "deepgram"
+                                ]
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "stt_cbb66806",
+                                "pad": "service"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "stt_service",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxystatelesssource_2b7fb171",
+                "type": "ProxyStatelessSource",
+                "editor_name": "ProxyStatelessSource",
+                "editor_position": [
+                    768.0,
+                    -588.0
+                ],
+                "editor_dimensions": [
+                    288.0,
+                    168.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "createcontextmessage_54489e88",
+                            "pad": "context_message"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "new_user_message",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Proxy source pad for subgraph connections",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "source",
+                    "tags": [
+                        "stateless",
+                        "proxy"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_d5089820",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    264.0,
+                    108.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    168.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "list",
+                                "max_length": null,
+                                "item_type_constraints": [
+                                    {}
+                                ]
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "openaicompatiblellm_d2f7e473",
+                                "pad": "context"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "llm_context",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_cdda2d5d",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    264.0,
+                    288.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    168.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
                         "allowed_types": [
                             {
                                 "type": "node_reference",
@@ -1481,22 +1110,39 @@
                                     "ToolGroup"
                                 ]
                             }
-                        ]
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "openaicompatiblellm_d2f7e473",
+                                "pad": "tool_group"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
                     },
                     {
                         "id": "pad_id",
                         "group": "pad_id",
                         "type": "PropertySinkPad",
-                        "value": "tool_group",
-                        "next_pads": [],
-                        "previous_pad": null,
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
                         "allowed_types": [
                             {
                                 "type": "string",
                                 "max_length": null,
                                 "min_length": null
                             }
-                        ]
+                        ],
+                        "value": "tool_group",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
                     }
                 ],
                 "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
@@ -1506,6 +1152,749 @@
                     "tags": [
                         "property",
                         "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxystatelesssource_c70c3f18",
+                "type": "ProxyStatelessSource",
+                "editor_name": "ProxyStatelessSource",
+                "editor_position": [
+                    1032.0,
+                    288.0
+                ],
+                "editor_dimensions": [
+                    288.0,
+                    168.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "context_message"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "openaicompatiblellm_d2f7e473",
+                            "pad": "context_message"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "new_assistant_message",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Proxy source pad for subgraph connections",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "source",
+                    "tags": [
+                        "stateless",
+                        "proxy"
+                    ]
+                }
+            },
+            {
+                "id": "tts_b60f46fe",
+                "type": "TTS",
+                "editor_name": "TTS",
+                "editor_position": [
+                    1536.0,
+                    -108.0
+                ],
+                "editor_dimensions": [
+                    256.0,
+                    326.0
+                ],
+                "pads": [
+                    {
+                        "id": "service",
+                        "group": "service",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "gabber",
+                                    "cartesia",
+                                    "elevenlabs"
+                                ]
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "gabber",
+                                    "cartesia",
+                                    "elevenlabs"
+                                ]
+                            }
+                        ],
+                        "value": "gabber",
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_c8e20ba1",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "api_key",
+                        "group": "api_key",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": []
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": []
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_04cdf605",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "voice_id",
+                        "group": "voice_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "626c3b02-2d2a-4a93-b3e7-be35fd2b95cd",
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "proxypropertysink_bfd580b5",
+                            "pad": "proxy"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "text",
+                        "group": "text",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "text_stream"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "openaicompatiblellm_d2f7e473",
+                            "pad": "text_stream"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "audio",
+                        "group": "audio",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "proxystatelesssource_2f0186fe",
+                                "pad": "proxy"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "cancel_trigger",
+                        "group": "cancel_trigger",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "trigger"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "stt_cbb66806",
+                            "pad": "speech_started"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "complete_transcription",
+                        "group": "complete_transcription",
+                        "type": "StatelessSourcePad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Converts text to speech using Gabber's native TTS model",
+                "metadata": {
+                    "primary": "ai",
+                    "secondary": "audio",
+                    "tags": [
+                        "tts",
+                        "speech",
+                        "gabber"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_c8e20ba1",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    1140.0,
+                    -420.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    174.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "enum",
+                                "options": [
+                                    "gabber",
+                                    "cartesia",
+                                    "elevenlabs"
+                                ]
+                            }
+                        ],
+                        "value": "gabber",
+                        "next_pads": [
+                            {
+                                "node": "tts_b60f46fe",
+                                "pad": "service"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "tts_service",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_04cdf605",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    1140.0,
+                    -216.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    180.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": []
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "tts_b60f46fe",
+                                "pad": "api_key"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "tts_api_key",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_bfd580b5",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    1140.0,
+                    -24.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    180.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "tts_b60f46fe",
+                                "pad": "voice_id"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "tts_voice_id",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_db0b7b0c",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    264.0,
+                    480.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    180.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "https://api.openai.com/v1",
+                        "next_pads": [
+                            {
+                                "node": "openaicompatiblellm_d2f7e473",
+                                "pad": "base_url"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "llm_base_url",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_ffda675d",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    264.0,
+                    672.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    180.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "secret",
+                                "options": []
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [
+                            {
+                                "node": "openaicompatiblellm_d2f7e473",
+                                "pad": "api_key"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "llm_api_key",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxypropertysink_415afe7f",
+                "type": "ProxyPropertySink",
+                "editor_name": "ProxyPropertySink",
+                "editor_position": [
+                    264.0,
+                    864.0
+                ],
+                "editor_dimensions": [
+                    266.0,
+                    180.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "PropertySourcePad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "gpt-4.1-mini",
+                        "next_pads": [
+                            {
+                                "node": "openaicompatiblellm_d2f7e473",
+                                "pad": "model"
+                            }
+                        ],
+                        "previous_pad": null,
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "llm_model",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Create a property sink pad that is exposed when using your subgraph in a flow",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "sink",
+                    "tags": [
+                        "property",
+                        "sink"
+                    ]
+                }
+            },
+            {
+                "id": "proxystatelesssource_2f0186fe",
+                "type": "ProxyStatelessSource",
+                "editor_name": "ProxyStatelessSource",
+                "editor_position": [
+                    1896.0,
+                    -48.0
+                ],
+                "editor_dimensions": [
+                    288.0,
+                    168.0
+                ],
+                "pads": [
+                    {
+                        "id": "proxy",
+                        "group": "proxy",
+                        "type": "StatelessSinkPad",
+                        "default_allowed_types": null,
+                        "allowed_types": [
+                            {
+                                "type": "audio"
+                            }
+                        ],
+                        "value": null,
+                        "next_pads": [],
+                        "previous_pad": {
+                            "node": "tts_b60f46fe",
+                            "pad": "audio"
+                        },
+                        "pad_links": []
+                    },
+                    {
+                        "id": "pad_id",
+                        "group": "pad_id",
+                        "type": "PropertySinkPad",
+                        "default_allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "allowed_types": [
+                            {
+                                "type": "string",
+                                "max_length": null,
+                                "min_length": null
+                            }
+                        ],
+                        "value": "audio_out",
+                        "next_pads": [],
+                        "previous_pad": null,
+                        "pad_links": []
+                    }
+                ],
+                "description": "Proxy source pad for subgraph connections",
+                "metadata": {
+                    "primary": "subgraph",
+                    "secondary": "source",
+                    "tags": [
+                        "stateless",
+                        "proxy"
                     ]
                 }
             }

--- a/engine/src/core/editor/models.py
+++ b/engine/src/core/editor/models.py
@@ -140,10 +140,12 @@ class PadEditorRepresentation(BaseModel):
     id: str
     group: str
     type: str
+    default_allowed_types: list[types.PadType] | None  = None
+    allowed_types: list[types.PadType] | None = None
     value: Any | None = None
     next_pads: list[PadReference]
     previous_pad: PadReference | None = None
-    allowed_types: list[types.PadType] | None = None
+    pad_links: list[str] = []
 
     class Config:
         # Enable arbitrary types to allow Any

--- a/engine/src/core/editor/serialize.py
+++ b/engine/src/core/editor/serialize.py
@@ -88,6 +88,9 @@ def pad_editor_rep(p: pad.Pad):
     allowed_types: list[pad.types.PadType] | None = cast(
         list[pad.types.PadType], p.get_type_constraints()
     )
+    default_allowed_types: list[pad.types.PadType] | None = cast(
+        list[pad.types.PadType], p.get_default_type_constraints()
+    )
     return PadEditorRepresentation(
         id=p.get_id(),
         group=p.get_group(),
@@ -96,6 +99,8 @@ def pad_editor_rep(p: pad.Pad):
         next_pads=next_pads,
         previous_pad=previous_pad,
         allowed_types=allowed_types,
+        default_allowed_types=default_allowed_types,
+        pad_links=[l.get_id() for l in p._pad_links],
     )
 
 

--- a/engine/src/nodes/core/media/av_clip_zip.py
+++ b/engine/src/nodes/core/media/av_clip_zip.py
@@ -48,7 +48,7 @@ class AVClipZip(Node):
                     group="av_clip",
                 )
 
-        self.pads = [video_clip, audio_clip, av_clip]
+        self.pads = [audio_clip, video_clip, av_clip]
 
     async def run(self):
         video_clip_pad = cast(pad.StatelessSinkPad, self.get_pad_required("video_clip"))


### PR DESCRIPTION
Because nodes can change pads based on their values, there was no deterministic way of loading nodes/pads from a saved snapshot (unless we were to save the entire edit history). This caused some bugs and footguns with certain nodes.

This PR serializes more info about the pads (pad links, default pad types) so the entire graph can be reconstructed from the serialized snapshot.

Unfortunately this is a breaking change. Existing graphs and subgraphs will be broken. I think it's early enough to get away with this without a migration strategy but we will avoid future breaking changes like this.