### PR TITLE
Higher fidelity streaming

### DIFF
--- a/engine/gabber/nodes/core/debug/output.py
+++ b/engine/gabber/nodes/core/debug/output.py
@@ -100,6 +100,8 @@ class Output(Node):
             track = rtc.LocalVideoTrack.create_video_track(f"{self.id}:video", source)
             options = rtc.TrackPublishOptions()
             options.source = rtc.TrackSource.SOURCE_CAMERA
+            options.video_encoding.max_bitrate = 4_000_000
+            options.video_encoding.max_framerate = 24
             await self.room.local_participant.publish_track(track, options)
             async for f in video:
                 v_frame = f.value


### PR DESCRIPTION
Default to higher fidelity video quality. Might lower this to 2-3mbps but for now this is good and save CPU for some of the streaming use cases we're experimenting with RN.